### PR TITLE
Set java compiler version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -59,6 +61,15 @@
       </resource>
     </resources>
       <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.5.1</version>
+              <configuration>
+                  <source>${maven.compiler.source}</source>
+                  <target>${maven.compiler.target}</target>
+              </configuration>
+          </plugin>
           <plugin>
               <artifactId>maven-assembly-plugin</artifactId>
               <version>2.3</version>


### PR DESCRIPTION
Explicitly set java version to 1.7 to avoid IDE defaulting to 1.5 and running into compile time errors
